### PR TITLE
添加了sql query的对map[str]interface 和[]map[str]interface类型的映射转换

### DIFF
--- a/GoMybatis.go
+++ b/GoMybatis.go
@@ -2,13 +2,14 @@ package GoMybatis
 
 import (
 	"bytes"
-	"github.com/zhuxiujia/GoMybatis/ast"
-	"github.com/zhuxiujia/GoMybatis/lib/github.com/beevik/etree"
-	"github.com/zhuxiujia/GoMybatis/utils"
 	"log"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/zhuxiujia/GoMybatis/ast"
+	"github.com/zhuxiujia/GoMybatis/lib/github.com/beevik/etree"
+	"github.com/zhuxiujia/GoMybatis/utils"
 )
 
 const NewSessionFunc = "NewSession" //NewSession method,auto write implement body code
@@ -364,8 +365,8 @@ func exeMethodByXml(elementType ElementType, beanName string, sessionEngine Sess
 		defer func() {
 			if sessionEngine.LogEnable() {
 				var RowsAffected = "0"
-				if err == nil && res != nil {
-					RowsAffected = strconv.Itoa(len(res))
+				if err == nil && !res.IsBlank() {
+					RowsAffected = strconv.Itoa(res.Rows())
 				}
 				sessionEngine.LogSystem().SendLog("[GoMybatis] [", session.Id(), "] ReturnRows <== "+RowsAffected)
 				if err != nil {

--- a/GoMybatisEngine_test.go
+++ b/GoMybatisEngine_test.go
@@ -2,13 +2,14 @@ package GoMybatis
 
 import (
 	"fmt"
+	"sync"
+	"testing"
+	"time"
+
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/zhuxiujia/GoMybatis/example"
 	"github.com/zhuxiujia/GoMybatis/tx"
 	"github.com/zhuxiujia/GoMybatis/utils"
-	"sync"
-	"testing"
-	"time"
 )
 
 //假设Mysql 数据库查询时间为0，框架单协程的Benchmark性能
@@ -150,7 +151,7 @@ type TestSession struct {
 func (it *TestSession) Id() string {
 	return "sadf"
 }
-/*func (it *TestSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
+func (it *TestSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
 	resultsSlice := make([]map[string][]byte, 0)
 
 	result := make(map[string][]byte)
@@ -161,7 +162,7 @@ func (it *TestSession) Id() string {
 	result["remark"] = []byte("活动1")
 	resultsSlice = append(resultsSlice, result)
 	return resultsSlice, nil
-}*/
+}
 func (it *TestSession) Exec(sqlorArgs string) (*Result, error) {
 	return nil, nil
 }

--- a/GoMybatisEngine_test.go
+++ b/GoMybatisEngine_test.go
@@ -150,7 +150,7 @@ type TestSession struct {
 func (it *TestSession) Id() string {
 	return "sadf"
 }
-func (it *TestSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
+/*func (it *TestSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
 	resultsSlice := make([]map[string][]byte, 0)
 
 	result := make(map[string][]byte)
@@ -161,7 +161,7 @@ func (it *TestSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
 	result["remark"] = []byte("活动1")
 	resultsSlice = append(resultsSlice, result)
 	return resultsSlice, nil
-}
+}*/
 func (it *TestSession) Exec(sqlorArgs string) (*Result, error) {
 	return nil, nil
 }

--- a/GoMybatisEngine_test.go
+++ b/GoMybatisEngine_test.go
@@ -151,16 +151,15 @@ type TestSession struct {
 func (it *TestSession) Id() string {
 	return "sadf"
 }
-func (it *TestSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
-	resultsSlice := make([]map[string][]byte, 0)
-
+func (it *TestSession) Query(sqlorArgs string) (QueryResult, error) {
+	resultsSlice := QueryResult{}
 	result := make(map[string][]byte)
 	result["name"] = []byte("活动1")
 	result["id"] = []byte("125")
 	result["pc_link"] = []byte("http://www.baidu.com")
 	result["h5_link"] = []byte("http://www.baidu.com")
 	result["remark"] = []byte("活动1")
-	resultsSlice = append(resultsSlice, result)
+	resultsSlice.append(result)
 	return resultsSlice, nil
 }
 func (it *TestSession) Exec(sqlorArgs string) (*Result, error) {

--- a/GoMybatisSqlResultDecoder_test.go
+++ b/GoMybatisSqlResultDecoder_test.go
@@ -2,9 +2,10 @@ package GoMybatis
 
 import (
 	"fmt"
-	"github.com/zhuxiujia/GoMybatis/utils"
 	"testing"
 	"time"
+
+	"github.com/zhuxiujia/GoMybatis/utils"
 )
 
 type TestResult struct {
@@ -26,8 +27,8 @@ type TestResult struct {
 func Test_Convert_Basic_Type(t *testing.T) {
 	var resMap = make(map[string][]byte)
 	resMap["Amount1"] = []byte("1908")
-	var resMapArray = make([]map[string][]byte, 0)
-	resMapArray = append(resMapArray, resMap)
+	var resMapArray = QueryResult{}
+	resMapArray.append(resMap)
 
 	var intResult int
 	var error = GoMybatisSqlResultDecoder{}.Decode(nil, resMapArray, &intResult)
@@ -52,8 +53,8 @@ func Test_Convert_Basic_Type(t *testing.T) {
 
 	resMap = make(map[string][]byte)
 	resMap["Date"] = []byte(time.Now().Format(time.RFC3339))
-	resMapArray = make([]map[string][]byte, 0)
-	resMapArray = append(resMapArray, resMap)
+	resMapArray = QueryResult{}
+	resMapArray.append(resMap)
 	var timeResult time.Time
 	error = GoMybatisSqlResultDecoder{}.Decode(nil, resMapArray, &timeResult)
 	if error != nil {
@@ -67,8 +68,8 @@ func Test_Convert_Slice(t *testing.T) {
 	var resMap = make(map[string][]byte)
 	resMap["Amount1"] = []byte("1908")
 	resMap["Amount2"] = []byte("1901")
-	var resMapArray = make([]map[string][]byte, 0)
-	resMapArray = append(resMapArray, resMap)
+	var resMapArray = QueryResult{}
+	resMapArray.append(resMap)
 
 	var result []int
 	var error = GoMybatisSqlResultDecoder{}.Decode(nil, resMapArray, &result)
@@ -83,8 +84,8 @@ func Test_Convert_Map(t *testing.T) {
 	var resMap = make(map[string][]byte)
 	resMap["Amount1"] = []byte("1908")
 	resMap["Amount2"] = []byte("1901")
-	var resMapArray = make([]map[string][]byte, 0)
-	resMapArray = append(resMapArray, resMap)
+	var resMapArray = QueryResult{}
+	resMapArray.append(resMap)
 
 	var result map[string]string
 	var error = GoMybatisSqlResultDecoder{}.Decode(nil, resMapArray, &result)
@@ -93,7 +94,7 @@ func Test_Convert_Map(t *testing.T) {
 	}
 	fmt.Println("Test_Convert_Map", result)
 
-	resMapArray = append(resMapArray, resMap)
+	resMapArray.append(resMap)
 
 	var resultMapArray []map[string]string
 	error = GoMybatisSqlResultDecoder{}.Decode(nil, resMapArray, &resultMapArray)
@@ -105,7 +106,7 @@ func Test_Convert_Map(t *testing.T) {
 
 func Test_convert_struct(t *testing.T) {
 	var GoMybatisSqlResultDecoder = GoMybatisSqlResultDecoder{}
-	var res = make([]map[string][]byte, 0)
+	var res = QueryResult{}
 
 	var resMap = make(map[string][]byte)
 	resMap["Name"] = []byte("xiao ming")
@@ -120,7 +121,7 @@ func Test_convert_struct(t *testing.T) {
 	resMap["Age7"] = []byte("1908")
 	resMap["Age8"] = []byte("1908")
 	resMap["Bool"] = []byte("true")
-	res = append(res, resMap)
+	res.append(resMap)
 
 	var result TestResult
 	GoMybatisSqlResultDecoder.Decode(nil, res, &result)
@@ -130,7 +131,7 @@ func Test_convert_struct(t *testing.T) {
 
 func Test_Ignore_Case_Underscores(t *testing.T) {
 	var GoMybatisSqlResultDecoder = GoMybatisSqlResultDecoder{}
-	var res = make([]map[string][]byte, 0)
+	var res = QueryResult{}
 
 	var resMap = make(map[string][]byte)
 	resMap["name"] = []byte("xiao ming")
@@ -145,7 +146,7 @@ func Test_Ignore_Case_Underscores(t *testing.T) {
 	resMap["age_7"] = []byte("1908")
 	resMap["age_8"] = []byte("1908")
 	resMap["Bool"] = []byte("1")
-	res = append(res, resMap)
+	res.append(resMap)
 
 	var result TestResult
 	GoMybatisSqlResultDecoder.Decode(nil, res, &result)
@@ -155,7 +156,7 @@ func Test_Ignore_Case_Underscores(t *testing.T) {
 
 func Test_Ignore_Case_Underscores_Tps(t *testing.T) {
 	var GoMybatisSqlResultDecoder = GoMybatisSqlResultDecoder{}
-	var res = make([]map[string][]byte, 0)
+	var res = QueryResult{}
 
 	var resMap = make(map[string][]byte)
 	resMap["name"] = []byte("xiao ming")
@@ -170,7 +171,7 @@ func Test_Ignore_Case_Underscores_Tps(t *testing.T) {
 	resMap["age_7"] = []byte("1908")
 	resMap["age_8"] = []byte("1908")
 	resMap["Bool"] = []byte("1")
-	res = append(res, resMap)
+	res.append(resMap)
 
 	var result TestResult
 
@@ -183,7 +184,7 @@ func Test_Ignore_Case_Underscores_Tps(t *testing.T) {
 
 func Test_Decode_Interface(t *testing.T) {
 
-	var res = make([]map[string][]byte, 0)
+	var res = QueryResult{}
 	var resMap = make(map[string][]byte)
 	resMap["name"] = []byte("xiao ming")
 	resMap["Amount_1"] = []byte("1908.1")
@@ -197,7 +198,7 @@ func Test_Decode_Interface(t *testing.T) {
 	resMap["age_7"] = []byte("1908")
 	resMap["age_8"] = []byte("1908")
 	resMap["Bool"] = []byte("1")
-	res = append(res, resMap)
+	res.append(resMap)
 
 	var resultMap = make(map[string]*ResultProperty)
 	resultMap["id"] = &ResultProperty{
@@ -233,7 +234,7 @@ func Test_Decode_Interface(t *testing.T) {
 func Benchmark_Ignore_Case_Underscores(b *testing.B) {
 	b.StopTimer()
 	var GoMybatisSqlResultDecoder = GoMybatisSqlResultDecoder{}
-	var res = make([]map[string][]byte, 0)
+	var res = QueryResult{}
 
 	var resMap = make(map[string][]byte)
 	resMap["name"] = []byte("xiao ming")
@@ -248,7 +249,7 @@ func Benchmark_Ignore_Case_Underscores(b *testing.B) {
 	resMap["age_7"] = []byte("1908")
 	resMap["age_8"] = []byte("1908")
 	resMap["Bool"] = []byte("1")
-	res = append(res, resMap)
+	res.append(resMap)
 
 	var result TestResult
 

--- a/GoMybatisTempleteDecoder_test.go
+++ b/GoMybatisTempleteDecoder_test.go
@@ -84,7 +84,7 @@ type TempleteSession struct {
 func (it *TempleteSession) Id() string {
 	return "sadf"
 }
-/*func (it *TempleteSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
+func (it *TempleteSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
 	resultsSlice := make([]map[string][]byte, 0)
 
 	result := make(map[string][]byte)
@@ -95,7 +95,7 @@ func (it *TempleteSession) Id() string {
 	result["remark"] = []byte("活动1")
 	resultsSlice = append(resultsSlice, result)
 	return resultsSlice, nil
-}*/
+}
 func (it *TempleteSession) Exec(sqlorArgs string) (*Result, error) {
 	var result = Result{
 		LastInsertId: 1,

--- a/GoMybatisTempleteDecoder_test.go
+++ b/GoMybatisTempleteDecoder_test.go
@@ -84,7 +84,7 @@ type TempleteSession struct {
 func (it *TempleteSession) Id() string {
 	return "sadf"
 }
-func (it *TempleteSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
+/*func (it *TempleteSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
 	resultsSlice := make([]map[string][]byte, 0)
 
 	result := make(map[string][]byte)
@@ -95,7 +95,7 @@ func (it *TempleteSession) Query(sqlorArgs string) ([]map[string][]byte, error) 
 	result["remark"] = []byte("活动1")
 	resultsSlice = append(resultsSlice, result)
 	return resultsSlice, nil
-}
+}*/
 func (it *TempleteSession) Exec(sqlorArgs string) (*Result, error) {
 	var result = Result{
 		LastInsertId: 1,

--- a/GoMybatisTempleteDecoder_test.go
+++ b/GoMybatisTempleteDecoder_test.go
@@ -2,10 +2,11 @@ package GoMybatis
 
 import (
 	"fmt"
-	"github.com/zhuxiujia/GoMybatis/example"
-	"github.com/zhuxiujia/GoMybatis/tx"
 	"testing"
 	"time"
+
+	"github.com/zhuxiujia/GoMybatis/example"
+	"github.com/zhuxiujia/GoMybatis/tx"
 )
 
 type ExampleActivityMapper struct {
@@ -84,8 +85,8 @@ type TempleteSession struct {
 func (it *TempleteSession) Id() string {
 	return "sadf"
 }
-func (it *TempleteSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
-	resultsSlice := make([]map[string][]byte, 0)
+func (it *TempleteSession) Query(sqlorArgs string) (QueryResult, error) {
+	resultsSlice := QueryResult{}
 
 	result := make(map[string][]byte)
 	result["name"] = []byte("活动1")
@@ -93,7 +94,7 @@ func (it *TempleteSession) Query(sqlorArgs string) ([]map[string][]byte, error) 
 	result["pc_link"] = []byte("http://www.baidu.com")
 	result["h5_link"] = []byte("http://www.baidu.com")
 	result["remark"] = []byte("活动1")
-	resultsSlice = append(resultsSlice, result)
+	resultsSlice.append(result)
 	return resultsSlice, nil
 }
 func (it *TempleteSession) Exec(sqlorArgs string) (*Result, error) {
@@ -232,11 +233,9 @@ func TestGoMybatisTempleteDecoder_Delete(t *testing.T) {
 	time.Sleep(time.Second)
 }
 
-func TestInit(t *testing.T)  {
+func TestInit(t *testing.T) {
 	initMapperTest()
 }
-
-
 
 func initMapperTest() {
 	bytes := []byte(`<?xml version="1.0" encoding="UTF-8"?>

--- a/LocalSession.go
+++ b/LocalSession.go
@@ -273,9 +273,9 @@ func (it *LocalSession) Close() {
 	}
 }
 
-func (it *LocalSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
+func (it *LocalSession) Query(sqlorArgs string) (QueryResult, error) {
 	if it.isClosed == true {
-		return nil, utils.NewError("LocalSession", " can not Query() a Closed Session!")
+		return QueryResult{}, utils.NewError("LocalSession", " can not Query() a Closed Session!")
 	}
 	if it.newLocalSession != nil {
 		return it.newLocalSession.Query(sqlorArgs)
@@ -295,11 +295,11 @@ func (it *LocalSession) Query(sqlorArgs string) ([]map[string][]byte, error) {
 		defer rows.Close()
 	}
 	if err != nil {
-		return nil, err
+		return QueryResult{}, err
 	} else {
 		return rows2maps(rows)
 	}
-	return nil, nil
+	return QueryResult{}, nil
 }
 
 func (it *LocalSession) Exec(sqlorArgs string) (*Result, error) {

--- a/SessionFactorySession.go
+++ b/SessionFactorySession.go
@@ -16,9 +16,9 @@ func (it *SessionFactorySession) Id() string {
 	}
 	return it.Session.Id()
 }
-func (it *SessionFactorySession) Query(sqlorArgs string) ([]map[string][]byte, error) {
+func (it *SessionFactorySession) Query(sqlorArgs string) (QueryResult, error) {
 	if it.Session == nil {
-		return nil, utils.NewError("SessionFactorySession", " can not run Id(),it.Session == nil")
+		return QueryResult{}, utils.NewError("SessionFactorySession", " can not run Id(),it.Session == nil")
 	}
 	return it.Session.Query(sqlorArgs)
 }

--- a/SqlResultDecoder.go
+++ b/SqlResultDecoder.go
@@ -5,5 +5,5 @@ type SqlResultDecoder interface {
 	//resultMap = in xml resultMap element
 	//dbData = select the SqlResult
 	//decodeResultPtr = need decode result type
-	Decode(resultMap map[string]*ResultProperty, SqlResult []map[string][]byte, decodeResultPtr interface{}) error
+	Decode(resultMap map[string]*ResultProperty, SqlResult QueryResult, decodeResultPtr interface{}) error
 }


### PR DESCRIPTION
首先这个库很有爱，sql和运行程序分开维护很方便，
我的改动：我在 SqlEngine.go添加了type SqlType string 类型 目前仅仅支持了mySQL的全部字段类型，
 替换map[string][]byte 为SqlEngine.go 的QueryResult类型，添加列信息的简单描述，通过列信息反射对应的golang数据类型。